### PR TITLE
Derive `Hash` for `Pos`

### DIFF
--- a/src/position.rs
+++ b/src/position.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 /// Original position of element in source code
-#[derive(PartialOrd, Ord, PartialEq, Eq, Clone, Copy, Default)]
+#[derive(PartialOrd, Ord, PartialEq, Eq, Clone, Copy, Default, Hash)]
 pub struct Pos {
     /// One-based line number
     pub line: usize,


### PR DESCRIPTION
So they can be used in `HashSet` and `HashMap` collections.

Not sure if this was deliberate or not, but something I was missing in another project.