### PR TITLE
Ownership issue when parsing from borrowed query string

### DIFF
--- a/src/query/grammar.rs
+++ b/src/query/grammar.rs
@@ -290,4 +290,13 @@ mod test {
     fn large_integer() {
         ast("{ a(x: 10000000000000000000000000000 }");
     }
+
+    #[test]
+    fn owned_query_from_borrowed_str() {
+        // Not a 'static str because we want to test non-static lifetimes work
+        let query = format!("query Test {{ fieldHere }}");
+
+        let _parsed: Document<'static, String> = parse_query(&query).unwrap();
+    }
+
 }


### PR DESCRIPTION
On current master. I assumed a `Document<'static, String>` could be parsed from a borrowed (non-static) `&str`, since the API is ostensibly generic, but that doesn't seem to be possible. I wrote a test case to exhibit the problem.

Do we want to support this?