### PR TITLE
Using rustfix to convert to edition 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ homepage = "https://github.com/graphql-rust/graphql-parser"
 documentation = "https://docs.rs/graphql-parser"
 version = "0.2.3"
 authors = ["Paul Colomiets <paul@colomiets.name>"]
+edition = "2018"
 
 [dependencies]
 combine = "3.2.0"

--- a/src/common.rs
+++ b/src/common.rs
@@ -5,9 +5,9 @@ use combine::easy::Error;
 use combine::error::StreamError;
 use combine::combinator::{many, many1, optional, position, choice};
 
-use tokenizer::{Kind as T, Token, TokenStream};
-use helpers::{punct, ident, kind, name};
-use position::Pos;
+use crate::tokenizer::{Kind as T, Token, TokenStream};
+use crate::helpers::{punct, ident, kind, name};
+use crate::position::Pos;
 
 /// Text abstracts over types that hold a string value.
 /// It is used to make the AST generic over the string type.

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,7 +1,7 @@
 //! Formatting graphql
 use std::default::Default;
 
-use common::Directive;
+use crate::common::Directive;
 
 
 #[derive(Debug, PartialEq)]
@@ -131,7 +131,7 @@ impl<'a> Formatter<'a> {
 }
 
 pub(crate) fn format_directives<'a, T>(dirs: &[Directive<'a, T>], f: &mut Formatter) 
-    where T: ::common::Text<'a>,
+    where T: crate::common::Text<'a>,
 {
     for dir in dirs {
         f.write(" ");

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -4,8 +4,8 @@ use combine::{Parser, ConsumedResult, satisfy, StreamOnce};
 use combine::error::{Tracked};
 use combine::stream::easy::{Error, Errors, Info};
 
-use tokenizer::{TokenStream, Kind, Token};
-use position::Pos;
+use crate::tokenizer::{TokenStream, Kind, Token};
+use crate::position::Pos;
 
 use super::common::{Text};
 
@@ -20,7 +20,7 @@ pub struct TokenMatch<'a> {
 pub struct NameMatch<'a, T> 
     where T: Text<'a>
 {
-    phantom: PhantomData<(&'a T)>,
+    phantom: PhantomData<&'a T>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,6 @@
 //!
 #![warn(missing_debug_implementations)]
 
-extern crate combine;
 #[macro_use] extern crate failure;
 #[cfg(test)] #[macro_use] extern crate pretty_assertions;
 
@@ -107,7 +106,7 @@ mod helpers;
 pub mod query;
 pub mod schema;
 
-pub use query::parse_query;
-pub use schema::parse_schema;
-pub use position::Pos;
-pub use format::Style;
+pub use crate::query::parse_query;
+pub use crate::schema::parse_schema;
+pub use crate::position::Pos;
+pub use crate::format::Style;

--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -5,8 +5,8 @@
 //!
 //! [graphql grammar]: http://facebook.github.io/graphql/October2016/#sec-Appendix-Grammar-Summary
 //!
-use position::Pos;
-pub use common::{Directive, Number, Value, Text, Type};
+use crate::position::Pos;
+pub use crate::common::{Directive, Number, Value, Text, Type};
 
 /// Root of query data
 #[derive(Debug, Clone, PartialEq)]

--- a/src/query/error.rs
+++ b/src/query/error.rs
@@ -1,7 +1,7 @@
 use combine::easy::Errors;
 
-use tokenizer::Token;
-use position::Pos;
+use crate::tokenizer::Token;
+use crate::position::Pos;
 
 pub type InternalError<'a> = Errors<Token<'a>, Token<'a>, Pos>;
 

--- a/src/query/format.rs
+++ b/src/query/format.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 
-use ::format::{Displayable, Formatter, Style, format_directives};
+use crate::format::{Displayable, Formatter, Style, format_directives};
 
-use query::ast::*;
+use crate::query::ast::*;
 
 
 impl<'a, T: Text<'a>> Document<'a, T> 

--- a/src/query/grammar.rs
+++ b/src/query/grammar.rs
@@ -1,12 +1,12 @@
 use combine::{parser, ParseResult, Parser};
 use combine::combinator::{many1, eof, optional, position};
 
-use common::{Directive};
-use common::{directives, arguments, default_value, parse_type};
-use tokenizer::{TokenStream};
-use helpers::{punct, ident, name};
-use query::error::{ParseError};
-use query::ast::*;
+use crate::common::{Directive};
+use crate::common::{directives, arguments, default_value, parse_type};
+use crate::tokenizer::{TokenStream};
+use crate::helpers::{punct, ident, name};
+use crate::query::error::{ParseError};
+use crate::query::ast::*;
 
 pub fn field<'a, S>(input: &mut TokenStream<'a>)
     -> ParseResult<Field<'a, S>, TokenStream<'a>>
@@ -208,8 +208,8 @@ pub fn parse_query<'a, S>(s: &'a str) -> Result<Document<'a, S>, ParseError>
 
 #[cfg(test)]
 mod test {
-    use position::Pos;
-    use query::grammar::*;
+    use crate::position::Pos;
+    use crate::query::grammar::*;
     use super::parse_query;
 
     fn ast(s: &str) -> Document<String> {

--- a/src/schema/ast.rs
+++ b/src/schema/ast.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
-pub use common::{Directive, Type, Value, Text};
-use position::Pos;
+pub use crate::common::{Directive, Type, Value, Text};
+use crate::position::Pos;
 
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct Document<'a, T: Text<'a>> 

--- a/src/schema/error.rs
+++ b/src/schema/error.rs
@@ -1,7 +1,7 @@
 use combine::easy::Errors;
 
-use tokenizer::Token;
-use position::Pos;
+use crate::tokenizer::Token;
+use crate::position::Pos;
 
 pub type InternalError<'a> = Errors<Token<'a>, Token<'a>, Pos>;
 

--- a/src/schema/format.rs
+++ b/src/schema/format.rs
@@ -1,9 +1,9 @@
 use std::fmt;
 
-use ::format::{Displayable, Formatter, Style, format_directives};
-use ::common::Text;
+use crate::format::{Displayable, Formatter, Style, format_directives};
+use crate::common::Text;
 
-use schema::ast::*;
+use crate::schema::ast::*;
 
 
 impl<'a, T> Document<'a, T> 

--- a/src/schema/grammar.rs
+++ b/src/schema/grammar.rs
@@ -5,11 +5,11 @@ use combine::combinator::{many, many1, eof, optional, position, choice};
 use combine::combinator::{sep_by1};
 use failure::Fail;
 
-use tokenizer::{Kind as T, Token, TokenStream};
-use helpers::{punct, ident, kind, name};
-use common::{directives, string, default_value, parse_type, Text};
-use schema::error::{ParseError};
-use schema::ast::*;
+use crate::tokenizer::{Kind as T, Token, TokenStream};
+use crate::helpers::{punct, ident, kind, name};
+use crate::common::{directives, string, default_value, parse_type, Text};
+use crate::schema::error::{ParseError};
+use crate::schema::ast::*;
 
 
 pub fn schema<'a, S>(input: &mut TokenStream<'a>)
@@ -510,9 +510,9 @@ pub fn described_definition<'a, T>(input: &mut TokenStream<'a>)
         // that means parser will need to backtrace, and that in turn
         // means that error reporting is bad (along with performance)
         .map(|(descr, mut def)| {
-            use schema::ast::TypeDefinition::*;
-            use schema::ast::Definition::*;
-            use schema::ast::Definition::{TypeDefinition as T};
+            use crate::schema::ast::TypeDefinition::*;
+            use crate::schema::ast::Definition::*;
+            use crate::schema::ast::Definition::{TypeDefinition as T};
             match def {
                 T(Scalar(ref mut s)) => s.description = descr,
                 T(Object(ref mut o)) => o.description = descr,
@@ -574,8 +574,8 @@ pub fn parse_schema<'a, T>(s: &'a str) -> Result<Document<'a, T>, ParseError>
 
 #[cfg(test)]
 mod test {
-    use position::Pos;
-    use schema::grammar::*;
+    use crate::position::Pos;
+    use crate::schema::grammar::*;
     use super::parse_schema;
 
     fn ast(s: &str) -> Document<String> {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -5,7 +5,7 @@ use combine::error::{StreamError};
 use combine::stream::{Resetable};
 use combine::easy::{Error, Errors};
 
-use position::Pos;
+use crate::position::Pos;
 
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]

--- a/vagga.yaml
+++ b/vagga.yaml
@@ -34,16 +34,19 @@ containers:
     - !Install [ca-certificates, git, build-essential, vim]
 
     - !TarInstall
-      url: "https://static.rust-lang.org/dist/rust-1.38.0-x86_64-unknown-linux-gnu.tar.gz"
+      url: "https://static.rust-lang.org/dist/rust-1.42.0-x86_64-unknown-linux-gnu.tar.gz"
       script: "./install.sh --prefix=/usr \
                 --components=rustc,rust-std-x86_64-unknown-linux-gnu,cargo"
     - !TarInstall
-      url: "https://static.rust-lang.org/dist/rust-std-1.38.0-wasm32-unknown-unknown.tar.gz"
+      url: "https://static.rust-lang.org/dist/rust-std-1.42.0-wasm32-unknown-unknown.tar.gz"
       script: "./install.sh --prefix=/usr --components=rust-std-wasm32-unknown-unknown"
     - &bulk !Tar
       url: "https://github.com/tailhook/bulk/releases/download/v0.4.10/bulk-v0.4.10.tar.gz"
       sha256: 481513f8a0306a9857d045497fb5b50b50a51e9ff748909ecf7d2bda1de275ab
       path: /
+    - !Sh |
+        cargo install cargo-fix --root=/usr
+
 
     environ:
       HOME: /work/target


### PR DESCRIPTION
It looks like it is the time for upgrade :)

*(Also I'm going to get rid of `failure` as rust community steering towards using std error. So I'm probably use going to use `thiserror` for this crate)*