### PR TITLE
Use `thiserror` crate instead of `failure`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 
 [dependencies]
 combine = "3.2.0"
-failure = "0.1.1"
+thiserror = "1.0.11"
 
 [dev-dependencies]
 pretty_assertions = "0.5.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,11 +20,10 @@
 //! -------------------------------
 //!
 //! ```rust
-//! # extern crate failure;
 //! # extern crate graphql_parser;
-//! use graphql_parser::parse_query;
+//! use graphql_parser::query::{parse_query, ParseError};
 //!
-//! # fn parse() -> Result<(), failure::Error> {
+//! # fn parse() -> Result<(), ParseError> {
 //! let ast = parse_query::<&str>("query MyQuery { field1, field2 }")?;
 //! // Format canonical representation
 //! assert_eq!(format!("{}", ast), "\
@@ -44,11 +43,10 @@
 //! --------------------------------
 //!
 //! ```rust
-//! # extern crate failure;
 //! # extern crate graphql_parser;
-//! use graphql_parser::parse_schema;
+//! use graphql_parser::schema::{parse_schema, ParseError};
 //!
-//! # fn parse() -> Result<(), failure::Error> {
+//! # fn parse() -> Result<(), ParseError> {
 //! let ast = parse_schema::<String>(r#"
 //!     schema {
 //!         query: Query
@@ -93,7 +91,6 @@
 //!
 #![warn(missing_debug_implementations)]
 
-#[macro_use] extern crate failure;
 #[cfg(test)] #[macro_use] extern crate pretty_assertions;
 
 

--- a/src/query/error.rs
+++ b/src/query/error.rs
@@ -1,4 +1,5 @@
 use combine::easy::Errors;
+use thiserror::Error;
 
 use crate::tokenizer::Token;
 use crate::position::Pos;
@@ -10,8 +11,8 @@ pub type InternalError<'a> = Errors<Token<'a>, Token<'a>, Pos>;
 ///
 /// This structure is opaque for forward compatibility. We are exploring a
 /// way to improve both error message and API.
-#[derive(Fail, Debug)]
-#[fail(display="query parse error: {}", _0)]
+#[derive(Error, Debug)]
+#[error("query parse error: {}", _0)]
 pub struct ParseError(String);
 
 impl<'a> From<InternalError<'a>> for ParseError {

--- a/src/schema/ast.rs
+++ b/src/schema/ast.rs
@@ -1,10 +1,12 @@
 use std::str::FromStr;
 
+use thiserror::Error;
+
 pub use crate::common::{Directive, Type, Value, Text};
 use crate::position::Pos;
 
 #[derive(Debug, Clone, Default, PartialEq)]
-pub struct Document<'a, T: Text<'a>> 
+pub struct Document<'a, T: Text<'a>>
     where T: Text<'a>
 {
     pub definitions: Vec<Definition<'a, T>>,
@@ -55,7 +57,7 @@ pub struct ScalarType<'a, T: Text<'a>> {
     pub directives: Vec<Directive<'a, T>>,
 }
 
-impl<'a, T> ScalarType<'a, T> 
+impl<'a, T> ScalarType<'a, T>
     where T: Text<'a>
 {
     pub fn new(name: T::Value) -> Self {
@@ -75,7 +77,7 @@ pub struct ScalarTypeExtension<'a, T: Text<'a>> {
     pub directives: Vec<Directive<'a, T>>,
 }
 
-impl<'a, T> ScalarTypeExtension<'a, T> 
+impl<'a, T> ScalarTypeExtension<'a, T>
     where T: Text<'a>
 {
     pub fn new(name: T::Value) -> Self {
@@ -97,7 +99,7 @@ pub struct ObjectType<'a, T: Text<'a>> {
     pub fields: Vec<Field<'a, T>>,
 }
 
-impl<'a, T> ObjectType<'a, T> 
+impl<'a, T> ObjectType<'a, T>
     where T: Text<'a>
 {
     pub fn new(name: T::Value) -> Self {
@@ -121,7 +123,7 @@ pub struct ObjectTypeExtension<'a, T: Text<'a>> {
     pub fields: Vec<Field<'a, T>>,
 }
 
-impl<'a, T> ObjectTypeExtension<'a, T> 
+impl<'a, T> ObjectTypeExtension<'a, T>
     where T: Text<'a>
 {
     pub fn new(name: T::Value) -> Self {
@@ -164,7 +166,7 @@ pub struct InterfaceType<'a, T: Text<'a>> {
     pub fields: Vec<Field<'a, T>>,
 }
 
-impl<'a, T> InterfaceType<'a, T> 
+impl<'a, T> InterfaceType<'a, T>
     where T: Text<'a>
 {
     pub fn new(name: T::Value) -> Self {
@@ -186,7 +188,7 @@ pub struct InterfaceTypeExtension<'a, T: Text<'a>> {
     pub fields: Vec<Field<'a, T>>,
 }
 
-impl<'a, T> InterfaceTypeExtension<'a, T> 
+impl<'a, T> InterfaceTypeExtension<'a, T>
 where T: Text<'a>
 {
     pub fn new(name: T::Value) -> Self {
@@ -208,7 +210,7 @@ pub struct UnionType<'a, T: Text<'a>> {
     pub types: Vec<T::Value>,
 }
 
-impl<'a, T> UnionType<'a, T> 
+impl<'a, T> UnionType<'a, T>
 where T: Text<'a>
 {
     pub fn new(name: T::Value) -> Self {
@@ -230,7 +232,7 @@ pub struct UnionTypeExtension<'a, T: Text<'a>> {
     pub types: Vec<T::Value>,
 }
 
-impl<'a, T> UnionTypeExtension<'a, T> 
+impl<'a, T> UnionTypeExtension<'a, T>
 where T: Text<'a>
 {
     pub fn new(name: T::Value) -> Self {
@@ -252,7 +254,7 @@ pub struct EnumType<'a, T: Text<'a>> {
     pub values: Vec<EnumValue<'a, T>>,
 }
 
-impl<'a, T> EnumType<'a, T> 
+impl<'a, T> EnumType<'a, T>
 where T: Text<'a>
 {
     pub fn new(name: T::Value) -> Self {
@@ -274,7 +276,7 @@ pub struct EnumValue<'a, T: Text<'a>> {
     pub directives: Vec<Directive<'a, T>>,
 }
 
-impl<'a, T> EnumValue<'a, T> 
+impl<'a, T> EnumValue<'a, T>
 where T: Text<'a>
 {
     pub fn new(name: T::Value) -> Self {
@@ -295,7 +297,7 @@ pub struct EnumTypeExtension<'a, T: Text<'a>> {
     pub values: Vec<EnumValue<'a, T>>,
 }
 
-impl<'a, T> EnumTypeExtension<'a, T> 
+impl<'a, T> EnumTypeExtension<'a, T>
 where T: Text<'a>
 {
     pub fn new(name: T::Value) -> Self {
@@ -317,7 +319,7 @@ pub struct InputObjectType<'a, T: Text<'a>> {
     pub fields: Vec<InputValue<'a, T>>,
 }
 
-impl<'a, T> InputObjectType<'a, T> 
+impl<'a, T> InputObjectType<'a, T>
 where T: Text<'a>
 {
     pub fn new(name: T::Value) -> Self {
@@ -339,7 +341,7 @@ pub struct InputObjectTypeExtension<'a, T: Text<'a>> {
     pub fields: Vec<InputValue<'a, T>>,
 }
 
-impl<'a, T> InputObjectTypeExtension<'a, T> 
+impl<'a, T> InputObjectTypeExtension<'a, T>
 where T: Text<'a>
 {
     pub fn new(name: T::Value) -> Self {
@@ -386,7 +388,7 @@ pub struct DirectiveDefinition<'a, T: Text<'a>> {
     pub locations: Vec<DirectiveLocation>,
 }
 
-impl<'a, T> DirectiveDefinition<'a, T> 
+impl<'a, T> DirectiveDefinition<'a, T>
 where T: Text<'a>
 {
     pub fn new(name: T::Value) -> Self {
@@ -460,8 +462,8 @@ impl DirectiveLocation {
     }
 }
 
-#[derive(Debug, Fail)]
-#[fail(display = "invalid directive location")]
+#[derive(Debug, Error)]
+#[error("invalid directive location")]
 pub struct InvalidDirectiveLocation;
 
 

--- a/src/schema/error.rs
+++ b/src/schema/error.rs
@@ -1,4 +1,5 @@
 use combine::easy::Errors;
+use thiserror::Error;
 
 use crate::tokenizer::Token;
 use crate::position::Pos;
@@ -10,8 +11,8 @@ pub type InternalError<'a> = Errors<Token<'a>, Token<'a>, Pos>;
 ///
 /// This structure is opaque for forward compatibility. We are exploring a
 /// way to improve both error message and API.
-#[derive(Fail, Debug)]
-#[fail(display="schema parse error: {}", _0)]
+#[derive(Error, Debug)]
+#[error("schema parse error: {}", _0)]
 pub struct ParseError(String);
 
 impl<'a> From<InternalError<'a>> for ParseError {

--- a/src/schema/grammar.rs
+++ b/src/schema/grammar.rs
@@ -3,7 +3,6 @@ use combine::easy::{Error, Errors};
 use combine::error::StreamError;
 use combine::combinator::{many, many1, eof, optional, position, choice};
 use combine::combinator::{sep_by1};
-use failure::Fail;
 
 use crate::tokenizer::{Kind as T, Token, TokenStream};
 use crate::helpers::{punct, ident, kind, name};
@@ -460,8 +459,7 @@ pub fn directive_locations<'a>(input: &mut TokenStream<'a>)
         optional(punct("|"))
         .with(sep_by1(
             kind(T::Name)
-                .and_then(|tok| tok.value.parse::<DirectiveLocation>()
-                                .map_err(|e| e.compat())),
+                .and_then(|tok| tok.value.parse::<DirectiveLocation>()),
             punct("|")))
     )
         .map(|opt| opt.unwrap_or_else(Vec::new))
@@ -558,7 +556,7 @@ pub fn definition<'a, T>(input: &mut TokenStream<'a>)
 }
 
 /// Parses a piece of schema language and returns an AST
-pub fn parse_schema<'a, T>(s: &'a str) -> Result<Document<'a, T>, ParseError> 
+pub fn parse_schema<'a, T>(s: &'a str) -> Result<Document<'a, T>, ParseError>
     where T: Text<'a>,
 {
     let mut tokens = TokenStream::new(s);


### PR DESCRIPTION
While failure still gets a lot of downloads rust community is more or less steering towards using (and fixing) stdlib error type.