### PR TITLE
Added consume_definition

### DIFF
--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -19,7 +19,7 @@ impl<'a> Document<'a, String> {
         // To support both reference and owned values in the AST,
         // all string data is represented with the ::common::Str<'a, T: Text<'a>> 
         // wrapper type.
-        // This type must carry the liftetime of the query string,
+        // This type must carry the lifetime of the query string,
         // and is stored in a PhantomData value on the Str type.
         // When using owned String types, the actual lifetime of
         // the Ast nodes is 'static, since no references are kept,

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -6,6 +6,6 @@ mod format;
 mod grammar;
 
 
-pub use self::grammar::parse_query;
+pub use self::grammar::{parse_query, consume_definition};
 pub use self::error::ParseError;
 pub use self::ast::*;

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -32,6 +32,12 @@ pub struct TokenStream<'a> {
     next_state: Option<(usize, Token<'a>, usize, Pos)>,
 }
 
+impl TokenStream<'_> {
+    pub(crate) fn offset(&self) -> usize {
+        self.off
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct Checkpoint {
     position: Pos,


### PR DESCRIPTION
This PR adds a new API consume_query:

```
/// Parses a single ExecutableDefinition and returns an AST as well as the
/// remainder of the input which is unparsed
pub fn consume_definition<'a, S>(s: &'a str) -> Result<(Definition<'a, S>, &'a str), ParseError> where S: Text<'a> { ... }
```

There are 4 tests demonstrating the functionality.

Resolves #35
Replaces #36 