### PR TITLE
Security: Guard against stack overflow for deeply nested input

### DIFF
--- a/src/query/grammar.rs
+++ b/src/query/grammar.rs
@@ -290,4 +290,12 @@ mod test {
     fn large_integer() {
         ast("{ a(x: 10000000000000000000000000000 }");
     }
+
+    #[test]
+    fn recursion_too_deep() {
+        let query = format!("{}(b: {}{}){}", "{ a".repeat(30), "[".repeat(25), "]".repeat(25),  "}".repeat(30));
+        let result = parse_query::<&str>(&query);
+        let err = format!("{}", result.unwrap_err());
+        assert_eq!(&err, "query parse error: Parse error at 1:114\nExpected `]`\nRecursion limit exceeded\n")
+    }
 }


### PR DESCRIPTION
This prevents a stack overflow when parsing deeply nested input.

The default depth is hardcoded to 50, but a non-public API allows the value to be overridden. How to surface this (eg: overloads, or an Options object) is left to the core maintainers.