### PR TITLE
fix(query): support for nameless queries with vars

### DIFF
--- a/src/query/format.rs
+++ b/src/query/format.rs
@@ -156,15 +156,15 @@ impl<'a, T: Text<'a>> Displayable for Query<'a, T>
         if let Some(ref name) = self.name {
             f.write(" ");
             f.write(name.as_ref());
-            if !self.variable_definitions.is_empty() {
-                f.write("(");
-                self.variable_definitions[0].display(f);
-                for var in &self.variable_definitions[1..] {
-                    f.write(", ");
-                    var.display(f);
-                }
-                f.write(")");
+        }
+        if !self.variable_definitions.is_empty() {
+            f.write("(");
+            self.variable_definitions[0].display(f);
+            for var in &self.variable_definitions[1..] {
+                f.write(", ");
+                var.display(f);
             }
+            f.write(")");
         }
         format_directives(&self.directives, f);
         f.write(" ");

--- a/tests/queries/query_nameless_vars.graphql
+++ b/tests/queries/query_nameless_vars.graphql
@@ -1,0 +1,4 @@
+query($first: Int, $second: Int) {
+  field1(first: $first)
+  field2(second: $second)
+}

--- a/tests/queries/query_nameless_vars_multiple_fields.graphql
+++ b/tests/queries/query_nameless_vars_multiple_fields.graphql
@@ -1,0 +1,16 @@
+,,,,,,,,,,,,,,,,,
+query ,,,,,,, ($houseId: String!, $streetNumber: Int!) ,,,,,,,,,,,, { # comment
+,,,,,,,,,,,,,,,,,, # commas should be fine
+  house(id: $houseId) {
+    id
+    name
+    lat
+    lng
+  }
+  street(number: $streetNumber) { # this is a comment
+    id
+  }
+  houseStreet(id: $houseId, number: $streetNumber) {
+    id
+  }
+}

--- a/tests/queries/query_nameless_vars_multiple_fields_canonical.graphql
+++ b/tests/queries/query_nameless_vars_multiple_fields_canonical.graphql
@@ -1,0 +1,14 @@
+query($houseId: String!, $streetNumber: Int!) {
+  house(id: $houseId) {
+    id
+    name
+    lat
+    lng
+  }
+  street(number: $streetNumber) {
+    id
+  }
+  houseStreet(id: $houseId, number: $streetNumber) {
+    id
+  }
+}

--- a/tests/query_roundtrips.rs
+++ b/tests/query_roundtrips.rs
@@ -33,6 +33,8 @@ fn roundtrip2(filename: &str) {
 #[test] fn minimal_query() { roundtrip("minimal_query"); }
 #[test] fn named_query() { roundtrip("named_query"); }
 #[test] fn query_vars() { roundtrip("query_vars"); }
+#[test] fn query_nameless_vars() { roundtrip("query_nameless_vars"); }
+#[test] fn query_nameless_vars_multiple_fields() { roundtrip2("query_nameless_vars_multiple_fields"); }
 #[test] fn query_var_defaults() { roundtrip("query_var_defaults"); }
 #[test] fn query_var_defaults1() { roundtrip("query_var_default_string"); }
 #[test] fn query_var_defaults2() { roundtrip("query_var_default_float"); }


### PR DESCRIPTION
Fix #46