### PR TITLE
Add VARIABLE_DEFINITION directive location

### DIFF
--- a/src/schema/ast.rs
+++ b/src/schema/ast.rs
@@ -401,6 +401,7 @@ pub enum DirectiveLocation {
     EnumValue,
     InputObject,
     InputFieldDefinition,
+    VariableDefinition,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -451,6 +452,7 @@ impl DirectiveLocation {
             EnumValue => "ENUM_VALUE",
             InputObject => "INPUT_OBJECT",
             InputFieldDefinition => "INPUT_FIELD_DEFINITION",
+            VariableDefinition => "VARIABLE_DEFINITION",
         }
     }
 
@@ -478,6 +480,7 @@ impl DirectiveLocation {
             | EnumValue
             | InputObject
             | InputFieldDefinition
+            | VariableDefinition
                 => false,
         }
     }
@@ -517,6 +520,7 @@ impl FromStr for DirectiveLocation {
             "ENUM_VALUE" => EnumValue,
             "INPUT_OBJECT" => InputObject,
             "INPUT_FIELD_DEFINITION" => InputFieldDefinition,
+            "VARIABLE_DEFINITION" => VariableDefinition,
             _ => return Err(InvalidDirectiveLocation),
         };
 

--- a/tests/schema_roundtrips.rs
+++ b/tests/schema_roundtrips.rs
@@ -50,4 +50,5 @@ fn roundtrip2(filename: &str) {
 #[test] fn directive() { roundtrip("directive"); }
 #[test] fn kitchen_sink() { roundtrip2("kitchen-sink"); }
 #[test] fn directive_descriptions() { roundtrip2("directive_descriptions"); }
+#[test] fn directive_variable_definition() { roundtrip("directive_variable_definition"); }
 #[test] fn repeatable() {roundtrip("repeatable")}

--- a/tests/schemas/directive_variable_definition.graphql
+++ b/tests/schemas/directive_variable_definition.graphql
@@ -1,0 +1,1 @@
+directive @configurable on VARIABLE_DEFINITION


### PR DESCRIPTION
I have some schemas that have this directive location, and this crate
currently crashes while trying to parse it.