### PR TITLE
Make block strings parsing conform to GraphQL spec.

### DIFF
--- a/tests/queries/kitchen-sink_canonical.graphql
+++ b/tests/queries/kitchen-sink_canonical.graphql
@@ -41,11 +41,7 @@ subscription StoryLikeSubscription($input: StoryLikeSubscribeInput) {
 }
 
 fragment frag on Friend {
-  foo(size: $size, bar: $b, obj: {block: """
-
-    block string uses \"""
-
-  """, key: "value"})
+  foo(size: $size, bar: $b, obj: {block: "block string uses \"\"\"", key: "value"})
 }
 
 {

--- a/tests/schemas/directive_descriptions.graphql
+++ b/tests/schemas/directive_descriptions.graphql
@@ -1,5 +1,6 @@
 """
-Directs the executor to include this field or fragment only when the `if` argument is true.
+Directs the executor to include this field or
+fragment only when the `if` argument is true.
 """
 directive @include(
   """
@@ -9,7 +10,8 @@ directive @include(
 ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
 """
-Directs the executor to skip this field or fragment when the `if` argument is true.
+Directs the executor to skip this field or
+fragment when the `if` argument is true.
 """
 directive @skip(
   """

--- a/tests/schemas/directive_descriptions_canonical.graphql
+++ b/tests/schemas/directive_descriptions_canonical.graphql
@@ -1,13 +1,11 @@
 """
-  Directs the executor to include this field or fragment only when the `if` argument is true.
+  Directs the executor to include this field or
+  fragment only when the `if` argument is true.
 """
-directive @include("""
-  Included when true.
-""" if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+directive @include("Included when true." if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
 """
-  Directs the executor to skip this field or fragment when the `if` argument is true.
+  Directs the executor to skip this field or
+  fragment when the `if` argument is true.
 """
-directive @skip("""
-  Skipped when true.
-""" if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+directive @skip("Skipped when true." if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT


### PR DESCRIPTION
Fixes https://github.com/graphql-rust/graphql-parser/issues/74.

This PR makes block string parsing conform to GraphQL spec. In particular the parser now strips leading and trailing empty lines from block string values. This implementation closely follows the [reference JS implementation](https://github.com/graphql/graphql-js/blob/0b7590f0a2b65e6210da2e49be0d8e6c27781af2/src/language/blockString.ts).