### PR TITLE
build(deps): Update to `thiserror` version 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 
 [dependencies]
 combine = "4.6.6"
-thiserror = "1.0.11"
+thiserror = "2"
 
 [dev-dependencies]
 pretty_assertions = "0.5.0"


### PR DESCRIPTION
Depencency `thiserror` has some breaking changes, but non of them seem to impact `graphql-parser`.

`cargo semver-checks` reports no changes on the API.