### PR TITLE
style: Remove redundant bound

### DIFF
--- a/src/query/format.rs
+++ b/src/query/format.rs
@@ -5,8 +5,6 @@ use crate::format::{format_directives, Displayable, Formatter, Style};
 use crate::query::ast::*;
 
 impl<'a, T: Text<'a>> Document<'a, T>
-where
-    T: Text<'a>,
 {
     /// Format a document according to style
     pub fn format(&self, style: &Style) -> String {
@@ -24,8 +22,6 @@ fn to_string<T: Displayable>(v: &T) -> String {
 }
 
 impl<'a, T: Text<'a>> Displayable for Document<'a, T>
-where
-    T: Text<'a>,
 {
     fn display(&self, f: &mut Formatter) {
         for item in &self.definitions {
@@ -35,8 +31,6 @@ where
 }
 
 impl<'a, T: Text<'a>> Displayable for Definition<'a, T>
-where
-    T: Text<'a>,
 {
     fn display(&self, f: &mut Formatter) {
         match *self {
@@ -47,8 +41,6 @@ where
 }
 
 impl<'a, T: Text<'a>> Displayable for OperationDefinition<'a, T>
-where
-    T: Text<'a>,
 {
     fn display(&self, f: &mut Formatter) {
         match *self {
@@ -61,8 +53,6 @@ where
 }
 
 impl<'a, T: Text<'a>> Displayable for FragmentDefinition<'a, T>
-where
-    T: Text<'a>,
 {
     fn display(&self, f: &mut Formatter) {
         f.margin();
@@ -82,8 +72,6 @@ where
 }
 
 impl<'a, T: Text<'a>> Displayable for SelectionSet<'a, T>
-where
-    T: Text<'a>,
 {
     fn display(&self, f: &mut Formatter) {
         f.margin();
@@ -97,8 +85,6 @@ where
 }
 
 impl<'a, T: Text<'a>> Displayable for Selection<'a, T>
-where
-    T: Text<'a>,
 {
     fn display(&self, f: &mut Formatter) {
         match *self {
@@ -110,8 +96,6 @@ where
 }
 
 fn format_arguments<'a, T: Text<'a>>(arguments: &[(T::Value, Value<'a, T>)], f: &mut Formatter)
-where
-    T: Text<'a>,
 {
     if !arguments.is_empty() {
         f.start_argument_block('(');
@@ -131,8 +115,6 @@ where
 }
 
 impl<'a, T: Text<'a>> Displayable for Field<'a, T>
-where
-    T: Text<'a>,
 {
     fn display(&self, f: &mut Formatter) {
         f.indent();
@@ -157,8 +139,6 @@ where
 }
 
 impl<'a, T: Text<'a>> Displayable for Query<'a, T>
-where
-    T: Text<'a>,
 {
     fn display(&self, f: &mut Formatter) {
         f.margin();
@@ -188,8 +168,6 @@ where
 }
 
 impl<'a, T: Text<'a>> Displayable for Mutation<'a, T>
-where
-    T: Text<'a>,
 {
     fn display(&self, f: &mut Formatter) {
         f.margin();
@@ -219,8 +197,6 @@ where
 }
 
 impl<'a, T: Text<'a>> Displayable for Subscription<'a, T>
-where
-    T: Text<'a>,
 {
     fn display(&self, f: &mut Formatter) {
         f.margin();
@@ -248,8 +224,6 @@ where
 }
 
 impl<'a, T: Text<'a>> Displayable for VariableDefinition<'a, T>
-where
-    T: Text<'a>,
 {
     fn display(&self, f: &mut Formatter) {
         f.write("$");
@@ -264,8 +238,6 @@ where
 }
 
 impl<'a, T: Text<'a>> Displayable for Type<'a, T>
-where
-    T: Text<'a>,
 {
     fn display(&self, f: &mut Formatter) {
         match *self {
@@ -284,8 +256,6 @@ where
 }
 
 impl<'a, T: Text<'a>> Displayable for Value<'a, T>
-where
-    T: Text<'a>,
 {
     fn display(&self, f: &mut Formatter) {
         match *self {
@@ -334,8 +304,6 @@ where
 }
 
 impl<'a, T: Text<'a>> Displayable for InlineFragment<'a, T>
-where
-    T: Text<'a>,
 {
     fn display(&self, f: &mut Formatter) {
         f.indent();
@@ -355,8 +323,6 @@ where
 }
 
 impl<'a, T: Text<'a>> Displayable for TypeCondition<'a, T>
-where
-    T: Text<'a>,
 {
     fn display(&self, f: &mut Formatter) {
         match *self {
@@ -369,8 +335,6 @@ where
 }
 
 impl<'a, T: Text<'a>> Displayable for FragmentSpread<'a, T>
-where
-    T: Text<'a>,
 {
     fn display(&self, f: &mut Formatter) {
         f.indent();
@@ -382,8 +346,6 @@ where
 }
 
 impl<'a, T: Text<'a>> Displayable for Directive<'a, T>
-where
-    T: Text<'a>,
 {
     fn display(&self, f: &mut Formatter) {
         f.write("@");

--- a/src/query/grammar.rs
+++ b/src/query/grammar.rs
@@ -101,8 +101,6 @@ where
 pub fn query<'a, T: Text<'a>>(
     input: &mut TokenStream<'a>,
 ) -> StdParseResult<Query<'a, T>, TokenStream<'a>>
-where
-    T: Text<'a>,
 {
     position()
         .skip(ident("query"))
@@ -132,8 +130,6 @@ type OperationCommon<'a, T: Text<'a>> = (
 pub fn operation_common<'a, T: Text<'a>>(
     input: &mut TokenStream<'a>,
 ) -> StdParseResult<OperationCommon<'a, T>, TokenStream<'a>>
-where
-    T: Text<'a>,
 {
     optional(name::<'a, T>())
         .and(
@@ -169,8 +165,6 @@ where
 pub fn mutation<'a, T: Text<'a>>(
     input: &mut TokenStream<'a>,
 ) -> StdParseResult<Mutation<'a, T>, TokenStream<'a>>
-where
-    T: Text<'a>,
 {
     position()
         .skip(ident("mutation"))
@@ -191,8 +185,6 @@ where
 pub fn subscription<'a, T: Text<'a>>(
     input: &mut TokenStream<'a>,
 ) -> StdParseResult<Subscription<'a, T>, TokenStream<'a>>
-where
-    T: Text<'a>,
 {
     position()
         .skip(ident("subscription"))
@@ -228,8 +220,6 @@ where
 pub fn fragment_definition<'a, T: Text<'a>>(
     input: &mut TokenStream<'a>,
 ) -> StdParseResult<FragmentDefinition<'a, T>, TokenStream<'a>>
-where
-    T: Text<'a>,
 {
     (
         position().skip(ident("fragment")),

--- a/src/schema/ast.rs
+++ b/src/schema/ast.rs
@@ -7,7 +7,6 @@ use crate::position::Pos;
 
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct Document<'a, T: Text<'a>>
-    where T: Text<'a>
 {
     pub definitions: Vec<Definition<'a, T>>,
 }


### PR DESCRIPTION
Remove `where` bound when the same bound is already specified.

This solves clippy warnings like this:
```
warning: bound is defined in more than one place
   --> src/query/grammar.rs:169:21
    |
169 | pub fn mutation<'a, T: Text<'a>>(
    |                     ^
...
173 |     T: Text<'a>,
    |     ^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#multiple_bound_locations
```