### PR TITLE
style: Remove unneeded `return` statement

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -223,7 +223,7 @@ fn unquote_block_string(src: &str) -> Result<String, Error<Token<'_>, Token<'_>>
             result.push_str(&line);
         }
     }
-    return Ok(result);
+    Ok(result)
 }
 
 fn unquote_string(s: &str) -> Result<String, Error<Token, Token>> {
@@ -476,6 +476,6 @@ mod tests {
     }
 
     fn triple_quote(input: &str) -> String {
-        return format!("\"\"\"{}\"\"\"", input);
+        format!("\"\"\"{}\"\"\"", input)
     }
 }


### PR DESCRIPTION
This solves clippy warnings like this:
```
error: unneeded `return` statement
   --> src/common.rs:226:5
    |
226 |     return Ok(result);
    |     ^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return
    = note: `-D clippy::needless-return` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::needless_return)]`
help: remove `return`
    |
226 -     return Ok(result);
226 +     Ok(result)
    |
```