### PR TITLE
style: Push single character instead of string

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -219,7 +219,7 @@ fn unquote_block_string(src: &str) -> Result<String, Error<Token<'_>, Token<'_>>
         result.push_str(&line);
 
         for line in lines {
-            result.push_str("\n");
+            result.push('\n');
             result.push_str(&line);
         }
     }


### PR DESCRIPTION
This solves clippy warnings like this:
```
error: calling `push_str()` using a single-character string literal
   --> src/common.rs:222:13
    |
222 |             result.push_str("\n");
    |             ^^^^^^^^^^^^^^^^^^^^^ help: consider using `push` with a character literal: `result.push('\n')`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_add_str
    = note: `-D clippy::single-char-add-str` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::single_char_add_str)]`
```