### PR TITLE
style: Use numeric constant

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -414,14 +414,8 @@ mod tests {
     fn number_from_i32_and_to_i64_conversion() {
         assert_eq!(Number::from(1).as_i64(), Some(1));
         assert_eq!(Number::from(584).as_i64(), Some(584));
-        assert_eq!(
-            Number::from(i32::min_value()).as_i64(),
-            Some(i32::min_value() as i64)
-        );
-        assert_eq!(
-            Number::from(i32::max_value()).as_i64(),
-            Some(i32::max_value() as i64)
-        );
+        assert_eq!(Number::from(i32::MIN).as_i64(), Some(i32::MIN as i64));
+        assert_eq!(Number::from(i32::MAX).as_i64(), Some(i32::MAX as i64));
     }
 
     #[test]


### PR DESCRIPTION
This solves clippy warnings like this:
```
error: usage of a legacy numeric method
   --> src/common.rs:418:31
    |
418 |             Number::from(i32::min_value()).as_i64(),
    |                               ^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#legacy_numeric_constants
    = note: `-D clippy::legacy-numeric-constants` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::legacy_numeric_constants)]`
help: use the associated constant instead
    |
418 |             Number::from(i32::MIN).as_i64(),
    |                               ~~~

```