### PR TITLE
style: Remove needless borrow

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -444,7 +444,7 @@ mod tests {
     fn block_string_leading_and_trailing_empty_lines() {
         let block = &triple_quote("   \n\n  Hello,\n    World!\n\n  Yours,\n    GraphQL.\n\n\n");
         assert_eq!(
-            unquote_block_string(&block),
+            unquote_block_string(block),
             Result::Ok("Hello,\n  World!\n\nYours,\n  GraphQL.".to_string())
         );
     }
@@ -453,7 +453,7 @@ mod tests {
     fn block_string_indent() {
         let block = &triple_quote("Hello   \n\n  Hello,\n    World!\n");
         assert_eq!(
-            unquote_block_string(&block),
+            unquote_block_string(block),
             Result::Ok("Hello   \n\nHello,\n  World!".to_string())
         );
     }


### PR DESCRIPTION
This solves clippy warnings like this:
```
error: this expression creates a reference which is immediately dereferenced by the compiler
   --> src/common.rs:447:34
    |
447 |             unquote_block_string(&block),
    |                                  ^^^^^^ help: change this to: `block`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
    = note: `-D clippy::needless-borrow` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::needless_borrow)]`
```