### PR TITLE
build: Make MSRV explicit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,12 @@ jobs:
         run: taplo lint
       - name: taplo fmt
         run: taplo fmt --check --diff
+
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: Swatinem/rust-cache@v2
+      - name: check with all-features
+        run: cargo hack --rust-version --no-private --no-dev-deps check --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ documentation = "https://docs.rs/graphql-parser"
 version = "0.4.1"
 authors = ["Paul Colomiets <paul@colomiets.name>"]
 edition = "2018"
+rust-version = "1.61"
 
 [dependencies]
 combine = "4.6.6"


### PR DESCRIPTION
Add `rust-version` to `Cargo.toml`. Verify this MSRV by adding a CI check that builds using that rust compiler version.

The current MSRV is 1.61. Trying to build with 1.60 results in:
```
error: package `syn v2.0.90` cannot be built because it requires rustc 1.61 or newer, while the currently active rustc version is 1.60.0
```