### PR TITLE
style: Remove needless lifetimes

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -27,7 +27,7 @@ impl<'a> Text<'a> for &'a str {
     type Value = Self;
 }
 
-impl<'a> Text<'a> for String {
+impl Text<'_> for String {
     type Value = String;
 }
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -47,7 +47,7 @@ pub(crate) trait Displayable {
     fn display(&self, f: &mut Formatter);
 }
 
-impl<'a> Formatter<'a> {
+impl Formatter<'_> {
     pub fn new(style: &Style) -> Formatter {
         Formatter {
             buf: String::with_capacity(1024),

--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -14,7 +14,7 @@ pub struct Document<'a, T: Text<'a>> {
     pub definitions: Vec<Definition<'a, T>>,
 }
 
-impl<'a> Document<'a, String> {
+impl Document<'_, String> {
     pub fn into_static(self) -> Document<'static, String> {
         // To support both reference and owned values in the AST,
         // all string data is represented with the ::common::Str<'a, T: Text<'a>>

--- a/src/schema/ast.rs
+++ b/src/schema/ast.rs
@@ -10,7 +10,7 @@ pub struct Document<'a, T: Text<'a>> {
     pub definitions: Vec<Definition<'a, T>>,
 }
 
-impl<'a> Document<'a, String> {
+impl Document<'_, String> {
     pub fn into_static(self) -> Document<'static, String> {
         // To support both reference and owned values in the AST,
         // all string data is represented with the ::common::Str<'a, T: Text<'a>>

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -68,13 +68,13 @@ impl<'a> StreamOnce for TokenStream<'a> {
     }
 }
 
-impl<'a> Positioned for TokenStream<'a> {
+impl Positioned for TokenStream<'_> {
     fn position(&self) -> Self::Position {
         self.position
     }
 }
 
-impl<'a> ResetStream for TokenStream<'a> {
+impl ResetStream for TokenStream<'_> {
     type Checkpoint = Checkpoint;
     fn checkpoint(&self) -> Self::Checkpoint {
         Checkpoint {
@@ -357,7 +357,7 @@ impl<'a> TokenStream<'a> {
     }
 }
 
-impl<'a> fmt::Display for Token<'a> {
+impl fmt::Display for Token<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}[{:?}]", self.value, self.kind)
     }


### PR DESCRIPTION
This solves clippy warnings like this:
```
error: the following explicit lifetimes could be elided: 'a
  --> src/common.rs:30:6
   |
30 | impl<'a> Text<'a> for String {
   |      ^^       ^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
   = note: `-D clippy::needless-lifetimes` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::needless_lifetimes)]`
help: elide the lifetimes
   |
30 - impl<'a> Text<'a> for String {
30 + impl Text<'_> for String {
```